### PR TITLE
Add missing lift variations, exports all lift variations

### DIFF
--- a/src/Data/Leibniz.purs
+++ b/src/Data/Leibniz.purs
@@ -7,11 +7,17 @@ module Data.Leibniz
   , coerceSymm
   , symm
   , liftLeibniz
-  , liftLeibniz2
-  , liftLeibniz3
+  , liftLeibniz1of2
+  , liftLeibniz2of2
+  , liftLeibniz1of3
+  , liftLeibniz2of3
+  , liftLeibniz3of3
   , lowerLeibniz
-  , lowerLeibniz2
-  , lowerLeibniz3
+  , lowerLeibniz1of2
+  , lowerLeibniz2of2
+  , lowerLeibniz1of3
+  , lowerLeibniz2of3
+  , lowerLeibniz3of3
   ) where
 
 import Prelude
@@ -50,33 +56,45 @@ liftLeibniz :: forall f a b. a ~ b -> f a ~ f b
 liftLeibniz _ = Leibniz unsafeCoerce
 
 -- | Lift equality over a type constructor.
-liftLeibniz2 :: forall f a b c. a ~ b -> f a c ~ f b c
-liftLeibniz2 _ = Leibniz unsafeCoerce
+liftLeibniz1of2 :: forall f a b c. a ~ b -> f a c ~ f b c
+liftLeibniz1of2 _ = Leibniz unsafeCoerce
 
 -- | Lift equality over a type constructor.
-liftLeibniz3 :: forall f a b c d. a ~ b -> f a c d ~ f b c d
-liftLeibniz3 _ = Leibniz unsafeCoerce
+liftLeibniz2of2 :: forall f a b c. a ~ b -> f c a ~ f c b
+liftLeibniz2of2 _ = Leibniz unsafeCoerce
+
+-- | Lift equality over a type constructor.
+liftLeibniz1of3 :: forall f a b c d. a ~ b -> f a c d ~ f b c d
+liftLeibniz1of3 _ = Leibniz unsafeCoerce
+
+-- | Lift equality over a type constructor.
+liftLeibniz2of3 :: forall f a b c d. a ~ b -> f c a d ~ f c b d
+liftLeibniz2of3 _ = Leibniz unsafeCoerce
+
+-- | Lift equality over a type constructor.
+liftLeibniz3of3 :: forall f a b c d. a ~ b -> f c d a ~ f c d b
+liftLeibniz3of3 _ = Leibniz unsafeCoerce
 
 -- | Every type constructor in PureScript is injective.
 lowerLeibniz :: forall f a b. f a ~ f b -> a ~ b
 lowerLeibniz _ = Leibniz unsafeCoerce
 
 -- | Every type constructor in PureScript is injective.
-lowerLeibniz2 :: forall f a b c d. f a c ~ f b d -> a ~ b
-lowerLeibniz2 _ = Leibniz unsafeCoerce
+lowerLeibniz1of2 :: forall f a b c d. f a c ~ f b d -> a ~ b
+lowerLeibniz1of2 _ = Leibniz unsafeCoerce
 
 -- | Every type constructor in PureScript is injective.
-lowerLeibniz2' :: forall f a b c d. f a c ~ f b d -> c ~ d
-lowerLeibniz2' _ = Leibniz unsafeCoerce
+lowerLeibniz2of2 :: forall f a b c d. f a c ~ f b d -> c ~ d
+lowerLeibniz2of2 _ = Leibniz unsafeCoerce
 
 -- | Every type constructor in PureScript is injective.
-lowerLeibniz3 :: forall f a b c d e g. f a b c ~ f d e g -> a ~ d
-lowerLeibniz3 _ = Leibniz unsafeCoerce
+lowerLeibniz1of3 :: forall f a b c d e g. f a b c ~ f d e g -> a ~ d
+lowerLeibniz1of3 _ = Leibniz unsafeCoerce
 
 -- | Every type constructor in PureScript is injective.
-lowerLeibniz3' :: forall f a b c d e g. f a b c ~ f d e g -> b ~ e
-lowerLeibniz3' _ = Leibniz unsafeCoerce
+lowerLeibniz2of3 :: forall f a b c d e g. f a b c ~ f d e g -> b ~ e
+lowerLeibniz2of3 _ = Leibniz unsafeCoerce
 
 -- | Every type constructor in PureScript is injective.
-lowerLeibniz3'' :: forall f a b c d e g. f a b c ~ f d e g -> c ~ g
-lowerLeibniz3'' _ = Leibniz unsafeCoerce
+lowerLeibniz3of3 :: forall f a b c d e g. f a b c ~ f d e g -> c ~ g
+lowerLeibniz3of3 _ = Leibniz unsafeCoerce


### PR DESCRIPTION
Since the functions weren't previously exported I gave them slightly more descriptive names, but if you'd prefer the primes I can change them back.