### PR TITLE
Relax the signatures for the `lowerLeibniz` variants

### DIFF
--- a/src/Data/Leibniz.purs
+++ b/src/Data/Leibniz.purs
@@ -86,27 +86,27 @@ liftLeibniz3of3 :: forall f a b c d. a ~ b -> f c d a ~ f c d b
 liftLeibniz3of3 _ = Leibniz unsafeCoerce
 
 -- | Every type constructor in PureScript is injective.
-lowerLeibniz :: forall f a b. f a ~ f b -> a ~ b
+lowerLeibniz :: forall f g a b. f a ~ g b -> a ~ b
 lowerLeibniz _ = Leibniz unsafeCoerce
 
 -- | Every type constructor in PureScript is injective.
-lowerLeibniz1of2 :: forall f a b c d. f a c ~ f b d -> a ~ b
+lowerLeibniz1of2 :: forall f g a b c d. f a c ~ g b d -> a ~ b
 lowerLeibniz1of2 _ = Leibniz unsafeCoerce
 
 -- | Every type constructor in PureScript is injective.
-lowerLeibniz2of2 :: forall f a b c d. f a c ~ f b d -> c ~ d
+lowerLeibniz2of2 :: forall f g a b c d. f a c ~ g b d -> c ~ d
 lowerLeibniz2of2 _ = Leibniz unsafeCoerce
 
 -- | Every type constructor in PureScript is injective.
-lowerLeibniz1of3 :: forall f a b c d e g. f a b c ~ f d e g -> a ~ d
+lowerLeibniz1of3 :: forall f g a b c d e h. f a b c ~ g d e h -> a ~ d
 lowerLeibniz1of3 _ = Leibniz unsafeCoerce
 
 -- | Every type constructor in PureScript is injective.
-lowerLeibniz2of3 :: forall f a b c d e g. f a b c ~ f d e g -> b ~ e
+lowerLeibniz2of3 :: forall f g a b c d e h. f a b c ~ g d e h -> b ~ e
 lowerLeibniz2of3 _ = Leibniz unsafeCoerce
 
 -- | Every type constructor in PureScript is injective.
-lowerLeibniz3of3 :: forall f a b c d e g. f a b c ~ f d e g -> c ~ g
+lowerLeibniz3of3 :: forall f g a b c d e h. f a b c ~ g d e h -> c ~ h
 lowerLeibniz3of3 _ = Leibniz unsafeCoerce
 
 -- | This class is used in the definition of the `refute` function.


### PR DESCRIPTION
As described in #9, this would add something equivalent to the `inner` function from [Haskell's GADT type equality library]( https://hackage.haskell.org/package/base-4.10.1.0/docs/Data-Type-Equality.html).

As requested, I'm targeting the `compiler/0.12` branch. I've updated the dependencies to match the now-published versions of the dependencies for the 0.12.0 compiler.

For the `inner` I described in #9, it seemed to me that it was basically equivalent to relaxing the type signature for `lowerLeibniz` ... so I've done that here, for each of the variants, instead of having a separate `inner` function. (Otherwise, in the absence of polykinds, we'd really need a bunch of variants for an `inner`).

I also described `outer` in #9, but now that I look at it more deeply, there are some additional things to think about there. So, I'll add a comment to the discussion in #9 about that.