### PR TITLE
Add `applyLeibniz` and variants

### DIFF
--- a/src/Data/Leibniz.purs
+++ b/src/Data/Leibniz.purs
@@ -12,6 +12,12 @@ module Data.Leibniz
   , liftLeibniz1of3
   , liftLeibniz2of3
   , liftLeibniz3of3
+  , applyLeibniz
+  , applyLeibniz1of2
+  , applyLeibniz2of2
+  , applyLeibniz1of3
+  , applyLeibniz2of3
+  , applyLeibniz3of3
   , lowerLeibniz
   , lowerLeibniz1of2
   , lowerLeibniz2of2
@@ -63,27 +69,51 @@ coerceSymm _ = unsafeCoerce
 
 -- | Lift equality over a type constructor.
 liftLeibniz :: forall f a b. a ~ b -> f a ~ f b
-liftLeibniz _ = Leibniz unsafeCoerce
+liftLeibniz = applyLeibniz identity
 
 -- | Lift equality over a type constructor.
 liftLeibniz1of2 :: forall f a b c. a ~ b -> f a c ~ f b c
-liftLeibniz1of2 _ = Leibniz unsafeCoerce
+liftLeibniz1of2 = applyLeibniz1of2 identity
 
 -- | Lift equality over a type constructor.
 liftLeibniz2of2 :: forall f a b c. a ~ b -> f c a ~ f c b
-liftLeibniz2of2 _ = Leibniz unsafeCoerce
+liftLeibniz2of2 = applyLeibniz2of2 identity
 
 -- | Lift equality over a type constructor.
 liftLeibniz1of3 :: forall f a b c d. a ~ b -> f a c d ~ f b c d
-liftLeibniz1of3 _ = Leibniz unsafeCoerce
+liftLeibniz1of3 = applyLeibniz1of3 identity
 
 -- | Lift equality over a type constructor.
 liftLeibniz2of3 :: forall f a b c d. a ~ b -> f c a d ~ f c b d
-liftLeibniz2of3 _ = Leibniz unsafeCoerce
+liftLeibniz2of3 = applyLeibniz2of3 identity
 
 -- | Lift equality over a type constructor.
 liftLeibniz3of3 :: forall f a b c d. a ~ b -> f c d a ~ f c d b
-liftLeibniz3of3 _ = Leibniz unsafeCoerce
+liftLeibniz3of3 = applyLeibniz3of3 identity
+
+-- | Apply an equality of type constructors to an equality of types.
+applyLeibniz :: forall f g a b c d. f c ~ g d -> a ~ b -> f a ~ g b
+applyLeibniz _ _ = Leibniz unsafeCoerce
+
+-- | Apply an equality of type constructors to an equality of types.
+applyLeibniz1of2 :: forall f g f1 f2 g1 g2 a b c. f f1 f2 ~ g g1 g2 -> a ~ b -> f a c ~ g b c
+applyLeibniz1of2 _ _ = Leibniz unsafeCoerce
+
+-- | Apply an equality of type constructors to an equality of types.
+applyLeibniz2of2 :: forall f g f1 f2 g1 g2 a b c. f f1 f2 ~ g g1 g2 -> a ~ b -> f c a ~ g c b
+applyLeibniz2of2 _ _ = Leibniz unsafeCoerce
+
+-- | Apply an equality of type constructors to an equality of types.
+applyLeibniz1of3 :: forall f g f1 f2 f3 g1 g2 g3 a b c d. f f1 f2 f3 ~ g g1 g2 g3 -> a ~ b -> f a c d ~ g b c d
+applyLeibniz1of3 _ _ = Leibniz unsafeCoerce
+
+-- | Apply an equality of type constructors to an equality of types.
+applyLeibniz2of3 :: forall f g f1 f2 f3 g1 g2 g3 a b c d. f f1 f2 f3 ~ g g1 g2 g3 -> a ~ b -> f c a d ~ g c b d
+applyLeibniz2of3 _ _ = Leibniz unsafeCoerce
+
+-- | Apply an equality of type constructors to an equality of types.
+applyLeibniz3of3 :: forall f g f1 f2 f3 g1 g2 g3 a b c d. f f1 f2 f3 ~ g g1 g2 g3 -> a ~ b -> f c d a ~ g c d b
+applyLeibniz3of3 _ _ = Leibniz unsafeCoerce
 
 -- | Every type constructor in PureScript is injective.
 lowerLeibniz :: forall f a b. f a ~ f b -> a ~ b


### PR DESCRIPTION
Building on the discussion in #9, this adds `applyLeibniz` and variously-kinded variants.

The `applyLeibniz` functions are essentially analogous to `liftLeibniz`, except that you provide two parameters. The first parameter proves the equality of the type constructors. The second parameter proves the equality of one of the type arguments. So, you lift the "distinct but equal" type arguments into distinct but equal type constructors (rather than requiring that the type constructors match up-front).

In terms of the [Haskell GADT type equality library](https://hackage.haskell.org/package/base-4.10.1.0/docs/Data-Type-Equality.html), this represents a combination of `outer` and `apply`, which are there defined as:

```haskell
apply :: (f :~: g) -> (a :~: b) -> f a :~: g b
outer :: (f a :~: g b) -> f :~: g
```

Unless I'm missing something, those definitions only make sense if you have polykinds. Basically, `apply` lets you do type application (whatever the kinds), and `outer` supplies the needed evidence about the type constructors (again, whatever the kinds).

In the absence of polykinds, I think we need to combine `apply` and `outer` in something I've proposed we call `applyLeibniz`.

Note that `liftLeibniz` and variants are now implemented in terms of `applyLeibniz` and variants, because the `liftLeibniz` signatures allow us to provide trivial evidence of the equality of the type constructors. 

So, `applyLeibniz` requires two parameters: 

- evidence that the type constructors are equal
- evidence that the type arguments are equal

```purs
applyLeibniz :: forall f g a b c d. f c ~ g d -> a ~ b -> f a ~ g b
applyLeibniz _ _ = Leibniz unsafeCoerce
```

Whereas `liftLeibniz` only requires one parameter (as previously) ... since the type constructors necessarily match, we can use `identity` to supply the additional parameter.

```purs
liftLeibniz :: forall f a b. a ~ b -> f a ~ f b
liftLeibniz = applyLeibniz identity
```

It occurred to me to simply modify `liftLeibniz` to take the extra parameter, and document the breaking change (i.e. people would now have to say `liftLeibniz identity` where before they just said `liftLeibniz`). However, the signatures for some of the variants get a bit hairy ... e.g.

```purs
applyLeibniz3of3 :: forall f g f1 f2 f3 g1 g2 g3 a b c d. f f1 f2 f3 ~ g g1 g2 g3 -> a ~ b -> f c d a ~ g c d b
applyLeibniz3of3 _ _ = Leibniz unsafeCoerce
```

Given that many type variables, it seemed to me that retaining the current, simpler signature for `liftLeibniz3of3` had some value.

Note that it is because there are so many type variables that I started numbeing them -- I think it's easier to follow the logic that way, rather than using more letters.

So, I think this is the best we can do without polykinds, unless there's something I haven't thought of.

